### PR TITLE
Resolve errors that occur when there are spaces in filename

### DIFF
--- a/main.py
+++ b/main.py
@@ -215,7 +215,8 @@ def main(args):
         subprocess.run(f"chmod 0755 {tmpfolder}/deb/DEBIAN/postinst".split(), stdout=subprocess.DEVNULL)
         if app_executable is not None:
             print("Changing app executable permissions...")
-            subprocess.run(f"chmod 0755 {tmpfolder}/deb/Applications/{folder}/{app_executable}".split(), stdout=subprocess.DEVNULL)
+            full_path = "'" + tmpfolder + "/deb/Applications/" + folder + "/" + app_executable + "'"
+            os.system("chmod 0755 " + full_path)
         print("")
         
         # Sign the app
@@ -227,7 +228,8 @@ def main(args):
         else:
             print("Signing with ldid...")
             subprocess.run("chmod +x ldid".split(), stdout=subprocess.DEVNULL)
-            os.system(f"./ldid -Sapp.entitlements -M -Upassword -Kdev_certificate.p12 {tmpfolder}/deb/Applications/{folder}")
+            full_path = "'" + tmpfolder + "/deb/Applications/" + folder + "'"
+            os.system("./ldid -Sapp.entitlements -M -Upassword -Kdev_certificate.p12 " + full_path)
         print("")
 
         # Package the deb file

--- a/main.py
+++ b/main.py
@@ -292,7 +292,8 @@ def main(args):
         if args.codesign:
             print("Signing with codesign as it was specified...")
             subprocess.run(f"security import ./dev_certificate.p12 -P password -A".split(), stdout=subprocess.DEVNULL)
-            os.system(f"codesign -s 'Worth Doing Badly iPhone OS Application Signing' --force --deep --preserve-metadata=entitlements --entitlements=app.entitlements {tmpfolder}/deb/Applications/{folder}")
+            full_path = "'" + tmpfolder + "/deb/Applications/" + folder + "'"
+            os.system("codesign -s 'Worth Doing Badly iPhone OS Application Signing' --force --deep --preserve-metadata=entitlements --entitlements=app.entitlements " + full_path)
         else:
             print("Signing with ldid...")
             subprocess.run("chmod +x ldid".split(), stdout=subprocess.DEVNULL)


### PR DESCRIPTION
Hello, 

When I first ran this script, it finished creating the .deb successfully, but there were errors in the output that I think would cause issues if I installed the .deb. The errors were caused by the fact that I was running the script on an app which has a .app folder and executable with a space in the name. Here is the full output including those errors, for a fictitious app named "My App"

```
IPA Permasigner - Version ce62d1b
Program created by Nebula | Original scripts created by zhuowei | CoreTrust bypass by Linus Henze

[?] Would you like to use an IPA stored on the web, or on your system? [external, local] local
[*] Created temporary directory.

[?] Paste in the path to an IPA in your file system: /Users/kyle/permasigner/myapp.ipa

[*] Unzipping IPA...

[*] Reading plist...
Found plist!
Executable found.
Found information about the app!

[*] Preparing deb file...
Making directories...
Copying deb file scripts and control...
Copying app files...
Changing deb file scripts permissions...
Changing app executable permissions...
chmod: /var/folders/v_/3s54xln145jg8z_z9kw2mrsr0000gn/T/tmpyu9poc9x/deb/Applications/My: No such file or directory
chmod: App.app/My: No such file or directory
chmod: App: No such file or directory

[*] Signing app...
Signing with ldid...
ldid: /var/folders/v_/3s54xln145jg8z_z9kw2mrsr0000gn/T/tmpyu9poc9x/deb/Applications/My: No such file or directory

[*] Packaging the deb file...

[*] We are finished!
[*] Copy the newly created deb from the output folder to your jailbroken iDevice and install it!
[*] The app will continue to work when rebooted to stock.
```

This PR resolves these error messages by adding single quotes around the pathnames used in the commands. 