### PR TITLE
Allow IPA filenames relative to home instead of just absolute paths

### DIFF
--- a/permasigner/__main__.py
+++ b/permasigner/__main__.py
@@ -216,7 +216,10 @@ class Permasigner(object):
                     path = self.logger.ask("Paste in the path to an IPA in your file system: ")
 
                 path = path.strip().lstrip("'").rstrip("'")
-
+                
+                if path.startswith("~"):
+                    path = os.expanduser("~")+path.strip().lstrip("~")
+                
                 if Path(path).exists():
                     if path.endswith(".deb"):
                         if dpkg.in_path:

--- a/permasigner/__main__.py
+++ b/permasigner/__main__.py
@@ -218,7 +218,7 @@ class Permasigner(object):
                 path = path.strip().lstrip("'").rstrip("'")
                 
                 if path.startswith("~"):
-                    path = os.expanduser("~")+path.strip().lstrip("~")
+                    path = os.path.expanduser("~")+path.strip().lstrip("~")
                 
                 if Path(path).exists():
                     if path.endswith(".deb"):


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
It can be annoying to type the full path a file, especially if the it's inside the home directory

**Description**
This should let users use '~' to specify paths relative to their home directory so they don't have to fully type it out.  Tested on Linux and FreeBSD 13 (adding a separate PR for support)

**Checklist**

-   [x] The new code was tested. 
-   [x] The code isn't overly messy.